### PR TITLE
Add MacPro5,1 (Mid 2010/2012) template config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ configs/YourModel/
     └── fan.conf    # if applicable
 ```
 
+**Template configs** exist for models awaiting hardware testing — check
+`configs/MacPro5,1/` and `configs/MacPro7,1/` if you have one of those machines.
+These are ready for you to validate and refine with real hardware data.
+
 ### 5. Trim the Config
 
 Follow the pattern in `configs/MacPro6,1/config`:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A stock distro kernel ships with thousands of modules for hardware you'll never 
 
 | Model | Identifier | Status | Maintainer |
 |-------|-----------|--------|------------|
+| Mac Pro (Mid 2010 / Mid 2012) | `MacPro5,1` | 📋 Planned | community — [help wanted](configs/MacPro5,1/) |
 | Mac Pro (Late 2013) | `MacPro6,1` | ✅ Active | @wolffcatskyy |
 | *Your Mac here* | *submit a PR* | 🔜 | *you?* |
 
@@ -59,14 +60,16 @@ sudo pacman -U linux-macpro61-*.pkg.tar.zst
 ```
 linux-mac/
 ├── configs/
-│   └── MacPro6,1/
-│       ├── config              # kernel .config
-│       ├── README.md           # hardware matrix, what works
-│       ├── patches/            # model-specific kernel patches
-│       ├── sysctl.d/
-│       │   └── 99-macpro.conf  # performance tuning
-│       └── fan/
-│           └── macfanctld.conf # fan curve profiles
+│   ├── MacPro5,1/              # Mid 2010/2012 "Cheese Grater" (planned)
+│   ├── MacPro6,1/              # Late 2013 "Trash Can" (active)
+│   │   ├── config              # kernel .config
+│   │   ├── README.md           # hardware matrix, what works
+│   │   ├── patches/            # model-specific kernel patches
+│   │   ├── sysctl.d/
+│   │   │   └── 99-macpro.conf  # performance tuning
+│   │   └── fan/
+│   │       └── macfanctld.conf # fan curve profiles
+│   └── MacPro7,1/              # 2019 rack (planned)
 ├── packaging/
 │   ├── arch/
 │   │   └── PKGBUILD           # AUR-ready

--- a/configs/MacPro5,1/README.md
+++ b/configs/MacPro5,1/README.md
@@ -1,0 +1,120 @@
+# Mac Pro 5,1 (Mid 2010 / Mid 2012) — "Cheese Grater"
+
+> **Status: Template — needs real hardware testing**
+>
+> This configuration is based on Apple's published specs and community knowledge.
+> It has NOT been validated on actual hardware. If you have a Mac Pro 5,1,
+> please test and submit corrections via PR.
+
+## Hardware Specifications
+
+| Component | Details | Kernel Driver | Config Option |
+|-----------|---------|--------------|---------------|
+| **CPU** | Single/Dual Intel Xeon (Westmere-EP): W3530, W3680, X5650, X5690, etc. | — | `CONFIG_NR_CPUS=24` |
+| **GPU (stock)** | ATI Radeon HD 5770 (1GB) or HD 5870 (1GB) — Evergreen/Northern Islands | `radeon` or `amdgpu` | `CONFIG_DRM_RADEON=y` or `CONFIG_DRM_AMDGPU=y` + `CONFIG_DRM_AMDGPU_SI=y` |
+| **GPU (common upgrades)** | AMD RX 580, RX Vega 56/64, Nvidia GTX 680/780 (Kepler) | `amdgpu` / `nouveau` | See GPU section below |
+| **Ethernet** | Broadcom BCM57762 Dual Gigabit | `tg3` | `CONFIG_TIGON3=y` |
+| **Wi-Fi** | None stock (many add BCM94360CD via PCIe) | `brcmfmac`/`b43` | `CONFIG_BRCMFMAC=m` |
+| **Audio** | Intel HDA + Cirrus Logic CS4206 | `snd_hda_intel` | `CONFIG_SND_HDA_INTEL=y`, `CONFIG_SND_HDA_CODEC_CIRRUS=y` |
+| **Storage** | 4x 3.5" SATA bays (ICH10 AHCI), 2x internal SATA (optical) | `ahci` | `CONFIG_SATA_AHCI=y` |
+| **Storage (upgraded)** | NVMe via PCIe adapter (common upgrade) | `nvme` | `CONFIG_BLK_DEV_NVME=y` |
+| **FireWire** | 4x FireWire 800 (LSI FW643) | `firewire-ohci` | `CONFIG_FIREWIRE=y`, `CONFIG_FIREWIRE_OHCI=y` |
+| **Thunderbolt** | None | — | — |
+| **USB** | 5x USB 2.0 (EHCI/UHCI) | `ehci_hcd`/`uhci_hcd` | `CONFIG_USB_EHCI_HCD=y` |
+| **Thermal** | Apple SMC | `applesmc` | `CONFIG_SENSORS_APPLESMC=y` |
+| **Boot** | EFI (32-bit EFI on 2010 models, 64-bit on 2012 models) | — | `CONFIG_EFI=y`, `CONFIG_EFI_STUB=y`, `CONFIG_EFI_MIXED=y` |
+
+## GPU Details
+
+The Mac Pro 5,1 has a unique GPU situation — most owners have upgraded from the stock Radeon HD 5770/5870 to more modern cards. The kernel config must accommodate this.
+
+### Stock GPUs
+
+- **Radeon HD 5770** — Juniper XT (Evergreen, VLIW5)
+- **Radeon HD 5870** — Cypress XT (Evergreen, VLIW5)
+- Driver: `radeon` (legacy) or `amdgpu` with SI support
+- Firmware: `radeon/JUNIPER_*.bin` or `radeon/CYPRESS_*.bin`
+
+### Common GPU Upgrades
+
+| GPU | Architecture | Driver | Firmware | Notes |
+|-----|-------------|--------|----------|-------|
+| AMD RX 580 | Polaris 20 (GCN 4) | `amdgpu` | `amdgpu/polaris10_*.bin` | Metal-capable, most popular upgrade |
+| AMD RX Vega 56/64 | Vega 10 (GCN 5) | `amdgpu` | `amdgpu/vega10_*.bin` | High performance |
+| AMD Radeon VII | Vega 20 (GCN 5.1) | `amdgpu` | `amdgpu/vega20_*.bin` | Workstation-class |
+| Nvidia GTX 680 | Kepler (GK104) | `nouveau` | N/A (open-source) | No macOS Metal support |
+| Nvidia GTX 780 | Kepler (GK110) | `nouveau` | N/A (open-source) | No macOS Metal support |
+
+**Recommendation:** The template config enables both `amdgpu` (with SI/CIK/Polaris/Vega support) and `nouveau`. Users should disable whichever they don't need.
+
+### Multi-GPU Configurations
+
+The 5,1 has 4 PCIe slots (2x x16, 1x x4, 1x x1), and multi-GPU setups are common. The kernel config supports multiple simultaneous GPU drivers if needed.
+
+## Hardware Compatibility Matrix
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Display (stock GPU) | 🔲 Untested | HD 5770/5870 via radeon driver |
+| Display (AMD upgrade) | 🔲 Untested | RX 580/Vega via amdgpu |
+| Display (Nvidia Kepler) | 🔲 Untested | GTX 680/780 via nouveau |
+| OpenGL | 🔲 Untested | Mesa radeonsi (AMD) or nouveau (Nvidia) |
+| Vulkan | 🔲 Untested | RADV (AMD) — no Vulkan for Kepler |
+| Ethernet | 🔲 Untested | Dual GbE via tg3 (same as 6,1) |
+| Wi-Fi (added) | 🔲 Untested | BCM94360CD via PCIe if installed |
+| Audio (3.5mm) | 🔲 Untested | Intel HDA + Cirrus CS4206 |
+| Audio (HDMI/DP) | 🔲 Untested | Via GPU audio |
+| FireWire 800 | 🔲 Untested | 4 ports via LSI FW643 |
+| USB 2.0 | 🔲 Untested | 5 ports via EHCI |
+| USB 3.0 (added) | 🔲 Untested | Via PCIe card if installed |
+| SATA (internal bays) | 🔲 Untested | 4x 3.5" + 2x optical via AHCI |
+| NVMe (added) | 🔲 Untested | Via PCIe adapter |
+| Sleep/Wake | ❓ Unknown | Historically problematic on Mac Pros |
+| Fan Control | 🔲 Untested | Via applesmc — different sensor layout than 6,1 |
+| Temperature Sensors | 🔲 Untested | Via applesmc + hwmon |
+
+## Known Considerations
+
+### 32-bit EFI (Mid 2010 models)
+Early Mac Pro 5,1 (and 4,1 flashed to 5,1) shipped with 32-bit EFI firmware. This requires `CONFIG_EFI_MIXED=y` to boot a 64-bit kernel from 32-bit EFI. The Mid 2012 revision has 64-bit EFI.
+
+### No Thunderbolt
+Unlike the 6,1, the 5,1 has no Thunderbolt — it uses FireWire 800 instead. The Thunderbolt kernel options can be disabled unless a Thunderbolt PCIe card has been added.
+
+### CPU Variety
+The 5,1 came with a wide range of CPUs, and many owners have upgraded:
+- Single-CPU configs: 4-6 cores (W3530, W3680)
+- Dual-CPU configs: 8-12 cores (X5650, X5660, X5670, X5680, X5690)
+- Max: Dual X5690 = 12 cores / 24 threads
+
+### GPU Power
+The PCIe slots provide limited auxiliary power. High-power GPUs (>225W) may need a pixlas mod or external power adapter. The kernel doesn't need to know about this, but it affects which GPUs are practically usable.
+
+## Model Variants
+
+| Model | CPU | GPU (stock) | RAM Max |
+|-------|-----|-------------|---------|
+| Mid 2010 (single) | W3530 (4C/8T, 2.8GHz) | Radeon HD 5770 (1GB) | 64GB |
+| Mid 2010 (single) | W3680 (6C/12T, 3.33GHz) | Radeon HD 5770 (1GB) | 64GB |
+| Mid 2010 (dual) | 2x X5650 (12C/24T, 2.66GHz) | Radeon HD 5770 (1GB) | 128GB |
+| Mid 2010 (dual) | 2x X5670 (12C/24T, 2.93GHz) | Radeon HD 5870 (1GB) | 128GB |
+| Mid 2012 (single) | W3680 (6C/12T, 3.33GHz) | Radeon HD 5770 (1GB) | 64GB |
+| Mid 2012 (dual) | 2x X5690 (12C/24T, 3.46GHz) | Radeon HD 5770 (1GB) | 128GB |
+| BTO Max | 2x X5690 (12C/24T, 3.46GHz) | Radeon HD 5870 (1GB) | 128GB |
+
+**Note:** RAM is DDR3 ECC. Single CPU configs use 4 DIMM slots (max 64GB), dual CPU configs use 8 DIMM slots (max 128GB with 16GB DIMMs).
+
+## PCI Device IDs (Stock Configuration)
+
+```
+GPU:      1002:68b8 (ATI Radeon HD 5770) or 1002:6898 (ATI Radeon HD 5870)
+NIC 1:    14e4:16b4 (Broadcom BCM57762)
+NIC 2:    14e4:16b4 (Broadcom BCM57762)
+FW:       11c1:5901 (LSI FW643 FireWire)
+HDA:      8086:3a6e (Intel 82801JI HD Audio)
+USB:      8086:3a34/3a35/3a36/3a37/3a38/3a39 (Intel ICH10 EHCI/UHCI)
+SATA:     8086:3a22 (Intel ICH10 AHCI)
+SMBus:    8086:3a30 (Intel ICH10 SMBus)
+```
+
+**Note:** PCI IDs will differ significantly if the GPU has been upgraded. Use `lspci -nn` on your system to verify.

--- a/configs/MacPro5,1/config
+++ b/configs/MacPro5,1/config
@@ -1,0 +1,523 @@
+#
+# linux-mac: Kernel configuration for Mac Pro 5,1 (Mid 2010 / Mid 2012)
+#
+# !! TEMPLATE — NOT TESTED ON REAL HARDWARE !!
+# This config is based on Apple specs and community knowledge.
+# It needs validation on an actual Mac Pro 5,1.
+# If you have one, please test and submit fixes via PR.
+#
+# Target: Linux 6.19
+# CPU: Intel Xeon Westmere-EP (W3530/W3680/X5650/X5690), up to 2 sockets
+# GPU: ATI Radeon HD 5770/5870 (stock) — see GPU section for upgrades
+# RAM: Up to 128GB ECC DDR3 (dual CPU), 64GB (single CPU)
+# Storage: 4x 3.5" SATA (ICH10 AHCI), common NVMe upgrade via PCIe
+# Network: Dual Broadcom BCM57762 GbE
+# Audio: Intel HDA + Cirrus Logic CS4206
+# FireWire: 4x FireWire 800 (LSI FW643)
+# Boot: EFI stub, no initramfs
+#
+# Philosophy: Everything needed is built-in (=y) where possible.
+# Modules (=m) for things that are optional or vary between machines.
+# Disabled (not set) for hardware this machine will never have.
+#
+# IMPORTANT: This config enables BOTH amdgpu and nouveau to cover
+# common GPU upgrades. Disable whichever you don't need for a smaller kernel.
+#
+
+# ============================================================
+# Architecture — must be explicitly set
+# ============================================================
+CONFIG_64BIT=y
+CONFIG_X86_64=y
+CONFIG_X86=y
+CONFIG_SMP=y
+CONFIG_NR_CPUS=24
+
+# ============================================================
+# General setup
+# ============================================================
+CONFIG_LOCALVERSION=""
+CONFIG_LOCALVERSION_AUTO=n
+CONFIG_DEFAULT_HOSTNAME="macpro"
+CONFIG_KERNEL_ZSTD=y
+CONFIG_SYSVIPC=y
+CONFIG_POSIX_MQUEUE=y
+CONFIG_AUDIT=y
+CONFIG_AUDITSYSCALL=y
+CONFIG_NO_HZ_FULL=y
+CONFIG_HIGH_RES_TIMERS=y
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+CONFIG_BPF_JIT_ALWAYS_ON=y
+CONFIG_BPF_LSM=y
+CONFIG_PREEMPT=y
+CONFIG_HZ_1000=y
+CONFIG_SCHED_AUTOGROUP=y
+CONFIG_SCHED_CORE=y
+CONFIG_TASKSTATS=y
+CONFIG_TASK_DELAY_ACCT=y
+CONFIG_TASK_XACCT=y
+CONFIG_TASK_IO_ACCOUNTING=y
+CONFIG_PSI=y
+CONFIG_FHANDLE=y
+CONFIG_EPOLL=y
+CONFIG_SIGNALFD=y
+CONFIG_TIMERFD=y
+CONFIG_EVENTFD=y
+CONFIG_SHMEM=y
+CONFIG_AIO=y
+CONFIG_ADVISE_SYSCALLS=y
+CONFIG_IO_URING=y
+CONFIG_KCMP=y
+CONFIG_CHECKPOINT_RESTORE=y
+CONFIG_CROSS_MEMORY_ATTACH=y
+
+# ============================================================
+# Modules — required for DKMS (broadcom-wl, etc.)
+# ============================================================
+CONFIG_MODULES=y
+CONFIG_MODULE_UNLOAD=y
+CONFIG_MODULE_FORCE_UNLOAD=y
+
+# ============================================================
+# Cgroups / Namespaces (Docker, systemd, containers)
+# ============================================================
+CONFIG_CGROUPS=y
+CONFIG_CGROUP_SCHED=y
+CONFIG_CGROUP_CPUACCT=y
+CONFIG_CGROUP_FREEZER=y
+CONFIG_CGROUP_DEVICE=y
+CONFIG_CGROUP_BPF=y
+CONFIG_CGROUP_PIDS=y
+CONFIG_CGROUP_HUGETLB=y
+CONFIG_CGROUP_PERF=y
+CONFIG_CGROUP_NET_PRIO=y
+CONFIG_MEMCG=y
+CONFIG_BLK_CGROUP=y
+CONFIG_PAGE_COUNTER=y
+CONFIG_NAMESPACES=y
+CONFIG_USER_NS=y
+CONFIG_NET_NS=y
+CONFIG_PID_NS=y
+CONFIG_IPC_NS=y
+CONFIG_UTS_NS=y
+
+# ============================================================
+# PCI / Block layer — fundamentals
+# ============================================================
+CONFIG_PCI=y
+CONFIG_PCIEPORTBUS=y
+CONFIG_HOTPLUG_PCI_PCIE=y
+CONFIG_BLOCK=y
+CONFIG_BLK_WBT=y
+CONFIG_MQ_DEADLINE=y
+CONFIG_BFQ_GROUP_IOSCHED=y
+
+# ============================================================
+# Processor (Westmere-EP / Nehalem)
+# ============================================================
+# Westmere is a die-shrink of Nehalem. CONFIG_GENERIC_CPU works fine.
+# For mainline, -march=native via MARCH_NATIVE (6.x+) is ideal.
+CONFIG_X86_MCE=y
+CONFIG_X86_MCE_INTEL=y
+CONFIG_MICROCODE=y
+CONFIG_MICROCODE_INTEL=y
+# CONFIG_MICROCODE_AMD is not set
+CONFIG_X86_MSR=y
+CONFIG_X86_CPUID=y
+# Dual-socket models are NUMA
+CONFIG_NUMA=y
+CONFIG_CPU_FREQ=y
+CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE=y
+CONFIG_CPU_FREQ_GOV_PERFORMANCE=y
+CONFIG_CPU_FREQ_GOV_POWERSAVE=y
+CONFIG_CPU_FREQ_GOV_ONDEMAND=y
+CONFIG_X86_ACPI_CPUFREQ=y
+CONFIG_X86_INTEL_PSTATE=y
+# CONFIG_X86_AMD_FREQ_SENSITIVITY is not set
+CONFIG_INTEL_IDLE=y
+
+# ============================================================
+# Memory management (32-128GB depending on config)
+# ============================================================
+CONFIG_TRANSPARENT_HUGEPAGE=y
+CONFIG_TRANSPARENT_HUGEPAGE_MADVISE=y
+CONFIG_ZSWAP=y
+CONFIG_ZSMALLOC=y
+CONFIG_SLAB_FREELIST_RANDOM=y
+CONFIG_SHUFFLE_PAGE_ALLOCATOR=y
+
+# ============================================================
+# Power management
+# ============================================================
+CONFIG_PM=y
+CONFIG_ACPI=y
+CONFIG_ACPI_PROCESSOR=y
+CONFIG_ACPI_THERMAL=y
+CONFIG_ACPI_FAN=y
+# CONFIG_ACPI_AC is not set
+# CONFIG_ACPI_BATTERY is not set
+# CONFIG_ACPI_SBS is not set
+
+# ============================================================
+# EFI / Boot (Apple EFI, no initramfs)
+# ============================================================
+# Note: Mid 2010 models have 32-bit EFI — EFI_MIXED is critical
+CONFIG_EFI=y
+CONFIG_EFI_STUB=y
+CONFIG_EFI_MIXED=y
+CONFIG_EFIVAR_FS=y
+CONFIG_FB_EFI=y
+CONFIG_FRAMEBUFFER_CONSOLE=y
+CONFIG_EFI_PARTITION=y
+# CONFIG_BLK_DEV_INITRD is not set
+
+# ============================================================
+# Firmware loading — support zstd-compressed firmware blobs
+# ============================================================
+CONFIG_FW_LOADER=y
+CONFIG_FW_LOADER_COMPRESS=y
+CONFIG_FW_LOADER_COMPRESS_ZSTD=y
+
+# GPU firmware blobs built into kernel (for boot without initramfs)
+# Stock HD 5770 (Juniper) firmware — change to match YOUR GPU
+# See README.md for firmware names for other GPUs
+CONFIG_EXTRA_FIRMWARE="radeon/JUNIPER_me.bin radeon/JUNIPER_pfp.bin radeon/JUNIPER_rlc.bin radeon/JUNIPER_smc.bin"
+CONFIG_EXTRA_FIRMWARE_DIR="/lib/firmware"
+
+# ============================================================
+# GPU — Stock ATI Radeon HD 5770/5870 + common upgrades
+# ============================================================
+# The 5,1 GPU situation is complex — most owners have upgraded.
+# This config enables multiple GPU driver families.
+# Disable what you don't need for a leaner kernel.
+
+# AMD GPU support (for stock Evergreen AND upgraded Polaris/Vega cards)
+CONFIG_DRM=y
+CONFIG_DRM_AMDGPU=y
+CONFIG_DRM_AMDGPU_SI=y
+CONFIG_DRM_AMDGPU_CIK=y
+CONFIG_DRM_AMDGPU_USERPTR=y
+CONFIG_HSA_AMD=y
+CONFIG_DRM_AMD_DC=y
+CONFIG_DRM_AMD_DC_SI=y
+
+# Legacy radeon driver (for stock HD 5770/5870 if amdgpu SI doesn't work)
+CONFIG_DRM_RADEON=m
+
+# Nvidia nouveau (for Kepler GPU upgrades — GTX 680/780)
+CONFIG_DRM_NOUVEAU=m
+
+# Disable other GPU drivers
+# CONFIG_DRM_I915 is not set
+# CONFIG_DRM_VGEM is not set
+# CONFIG_DRM_VMWGFX is not set
+# CONFIG_DRM_BOCHS is not set
+# CONFIG_DRM_AST is not set
+# CONFIG_DRM_MGAG200 is not set
+
+# ============================================================
+# KVM — for macOS virtualization
+# ============================================================
+CONFIG_VIRTUALIZATION=y
+CONFIG_KVM=y
+CONFIG_KVM_INTEL=y
+# CONFIG_KVM_AMD is not set
+CONFIG_VHOST=y
+CONFIG_VHOST_NET=y
+CONFIG_VHOST_VSOCK=y
+
+# Virtio for guests
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_PCI=y
+CONFIG_VIRTIO_NET=y
+CONFIG_VIRTIO_BLK=y
+CONFIG_VIRTIO_BALLOON=y
+CONFIG_DRM_VIRTIO_GPU=m
+CONFIG_DRM_QXL=m
+
+# ============================================================
+# Storage — ICH10 AHCI (SATA) + common NVMe upgrade
+# ============================================================
+CONFIG_SCSI=y
+CONFIG_BLK_DEV_SD=y
+CONFIG_BLK_DEV_SR=y
+CONFIG_CHR_DEV_SG=y
+CONFIG_ATA=y
+CONFIG_SATA_AHCI=y
+CONFIG_ATA_SFF=y
+CONFIG_ATA_BMDMA=y
+# NVMe via PCIe adapter (extremely common upgrade)
+CONFIG_BLK_DEV_NVME=y
+
+# Device mapper (for LUKS, LVM, etc.)
+CONFIG_BLK_DEV_DM=m
+CONFIG_DM_CRYPT=m
+CONFIG_DM_SNAPSHOT=m
+CONFIG_DM_MIRROR=m
+CONFIG_DM_ZERO=m
+
+# ============================================================
+# Filesystem
+# ============================================================
+CONFIG_EXT4_FS=y
+CONFIG_EXT4_FS_POSIX_ACL=y
+CONFIG_EXT4_FS_SECURITY=y
+CONFIG_XFS_FS=y
+CONFIG_BTRFS_FS=y
+CONFIG_TMPFS=y
+CONFIG_TMPFS_POSIX_ACL=y
+CONFIG_VFAT_FS=y
+CONFIG_FAT_DEFAULT_CODEPAGE=437
+CONFIG_NLS_CODEPAGE_437=y
+CONFIG_NLS_ISO8859_1=y
+CONFIG_NLS_ASCII=y
+CONFIG_NLS_UTF8=y
+CONFIG_NLS_DEFAULT="utf8"
+CONFIG_FAT_DEFAULT_UTF8=y
+CONFIG_FUSE_FS=y
+CONFIG_OVERLAY_FS=y
+CONFIG_PROC_FS=y
+CONFIG_SYSFS=y
+CONFIG_DEVTMPFS=y
+CONFIG_DEVTMPFS_MOUNT=y
+CONFIG_HFSPLUS_FS=m
+CONFIG_HFS_FS=m
+CONFIG_AUTOFS_FS=y
+# CONFIG_OCFS2_FS is not set
+# CONFIG_GFS2_FS is not set
+# CONFIG_NILFS2_FS is not set
+# CONFIG_F2FS_FS is not set
+# CONFIG_JFS_FS is not set
+# CONFIG_REISERFS_FS is not set
+
+# NFS client (for NAS mounts)
+CONFIG_NFS_FS=m
+CONFIG_NFS_V3=m
+CONFIG_NFS_V4=m
+CONFIG_LOCKD=m
+CONFIG_SUNRPC=m
+
+# ============================================================
+# Network — Broadcom BCM57762
+# ============================================================
+CONFIG_NET=y
+CONFIG_PACKET=y
+CONFIG_UNIX=y
+CONFIG_INET=y
+CONFIG_IPV6=y
+CONFIG_NETFILTER=y
+CONFIG_NF_CONNTRACK=y
+CONFIG_NETFILTER_XTABLES=y
+CONFIG_NF_NAT=y
+CONFIG_NF_TABLES=m
+CONFIG_IP_NF_IPTABLES=y
+CONFIG_IP_NF_FILTER=y
+CONFIG_IP_NF_NAT=y
+CONFIG_IP_NF_MANGLE=y
+CONFIG_IP_NF_TARGET_MASQUERADE=m
+CONFIG_IP6_NF_IPTABLES=m
+CONFIG_IP6_NF_FILTER=m
+CONFIG_IP6_NF_NAT=m
+CONFIG_BRIDGE=m
+CONFIG_BRIDGE_NETFILTER=m
+CONFIG_VLAN_8021Q=m
+CONFIG_NET_SCHED=y
+CONFIG_NET_SCH_FQ_CODEL=y
+CONFIG_NET_CLS_CGROUP=y
+
+# Wired — Broadcom BCM57762 (dual)
+CONFIG_NET_VENDOR_BROADCOM=y
+CONFIG_TIGON3=y
+
+# Wireless — no stock Wi-Fi, but BCM94360CD PCIe is common upgrade
+CONFIG_WLAN=y
+CONFIG_CFG80211=m
+CONFIG_MAC80211=m
+# CONFIG_B43 is not set
+CONFIG_BRCMFMAC=m
+CONFIG_BRCMUTIL=m
+
+# TCP
+CONFIG_TCP_CONG_ADVANCED=y
+CONFIG_TCP_CONG_BBR=y
+CONFIG_DEFAULT_BBR=y
+
+# Docker networking
+CONFIG_VETH=m
+CONFIG_MACVLAN=m
+CONFIG_IPVLAN=m
+CONFIG_VXLAN=m
+CONFIG_DUMMY=m
+CONFIG_TUN=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_IPVS=m
+CONFIG_IP_VS=m
+CONFIG_IP_VS_NFCT=y
+CONFIG_IP_VS_RR=m
+CONFIG_IP_VS_WRR=m
+CONFIG_IP_VS_SH=m
+CONFIG_IP_SET=m
+
+# Disable unused NIC vendors
+# CONFIG_NET_VENDOR_INTEL is not set
+# CONFIG_NET_VENDOR_REALTEK is not set
+# CONFIG_NET_VENDOR_QUALCOMM is not set
+# CONFIG_NET_VENDOR_MELLANOX is not set
+# CONFIG_NET_VENDOR_CHELSIO is not set
+# CONFIG_NET_VENDOR_MARVELL is not set
+# CONFIG_NET_VENDOR_AMD is not set
+# CONFIG_INFINIBAND is not set
+
+# ============================================================
+# Audio — Intel HDA (ICH10) + Cirrus Logic CS4206
+# ============================================================
+CONFIG_SOUND=y
+CONFIG_SND=y
+CONFIG_SND_PCI=y
+CONFIG_SND_HDA_INTEL=y
+CONFIG_SND_HDA_CODEC_CIRRUS=y
+CONFIG_SND_HDA_CODEC_CS420X=y
+CONFIG_SND_HDA_CODEC_HDMI=y
+CONFIG_SND_HDA_CODEC_ATIHDMI=y
+CONFIG_SND_HDA_GENERIC=y
+CONFIG_SND_USB=y
+CONFIG_SND_USB_AUDIO=m
+
+# ============================================================
+# USB — EHCI only (no xHCI stock, but PCIe USB 3.0 cards common)
+# ============================================================
+CONFIG_USB=y
+CONFIG_USB_XHCI_HCD=y
+CONFIG_USB_EHCI_HCD=y
+CONFIG_USB_OHCI_HCD=y
+CONFIG_USB_OHCI_HCD_PCI=y
+CONFIG_USB_UHCI_HCD=y
+CONFIG_USB_STORAGE=y
+CONFIG_USB_UAS=y
+CONFIG_USB_HID=y
+CONFIG_HID=y
+CONFIG_HID_GENERIC=y
+CONFIG_HID_APPLE=y
+CONFIG_HID_MULTITOUCH=m
+CONFIG_INPUT_EVDEV=y
+
+# ============================================================
+# Video — UVC (for USB webcams)
+# ============================================================
+CONFIG_MEDIA_SUPPORT=y
+CONFIG_MEDIA_USB_SUPPORT=y
+CONFIG_USB_VIDEO_CLASS=m
+CONFIG_VIDEO_DEV=y
+
+# ============================================================
+# FireWire (LSI FW643 — built in, NOT Thunderbolt)
+# ============================================================
+CONFIG_FIREWIRE=y
+CONFIG_FIREWIRE_OHCI=y
+CONFIG_FIREWIRE_SBP2=m
+CONFIG_FIREWIRE_NET=m
+
+# ============================================================
+# Thunderbolt — NOT present on stock 5,1
+# ============================================================
+# Enable as module in case someone adds a Thunderbolt PCIe card
+CONFIG_THUNDERBOLT=m
+
+# ============================================================
+# Intel chipset / platform drivers (ICH10 / X58 platform)
+# ============================================================
+CONFIG_DMADEVICES=y
+CONFIG_INTEL_IOATDMA=y
+CONFIG_DCA=y
+CONFIG_I2C=y
+CONFIG_I2C_I801=y
+CONFIG_I2C_SMBUS=y
+CONFIG_LPC_ICH=y
+CONFIG_INTEL_MEI=y
+CONFIG_INTEL_MEI_ME=y
+CONFIG_VIDEO=y
+CONFIG_WMI=y
+
+# ============================================================
+# Apple hardware
+# ============================================================
+CONFIG_HWMON=y
+CONFIG_THERMAL=y
+CONFIG_SENSORS_APPLESMC=y
+CONFIG_SENSORS_CORETEMP=y
+CONFIG_X86_PKG_TEMP_THERMAL=y
+CONFIG_APPLE_GMUX=y
+
+# Intel power management / performance monitoring
+CONFIG_INTEL_POWERCLAMP=m
+CONFIG_INTEL_RAPL=m
+CONFIG_INTEL_UNCORE=m
+CONFIG_INTEL_CSTATE=m
+CONFIG_EDAC=y
+
+# ============================================================
+# Crypto — hardware accelerated (AES-NI on Westmere)
+# ============================================================
+CONFIG_CRYPTO=y
+CONFIG_CRYPTO_AES=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+CONFIG_CRYPTO_HASH=y
+CONFIG_CRYPTO_HMAC=y
+CONFIG_CRYPTO_SHA256=y
+CONFIG_CRYPTO_SHA512=y
+CONFIG_CRYPTO_GHASH_CLMUL_NI_INTEL=y
+CONFIG_CRYPTO_USER_API=m
+CONFIG_CRYPTO_USER_API_HASH=m
+CONFIG_CRYPTO_USER_API_SKCIPHER=m
+CONFIG_KEY_DH_OPERATIONS=y
+
+# ============================================================
+# Security
+# ============================================================
+CONFIG_SECURITY=y
+CONFIG_SECURITYFS=y
+CONFIG_SECURITY_NETWORK=y
+CONFIG_LSM="landlock,lockdown,yama,integrity,apparmor,bpf"
+CONFIG_SECURITY_APPARMOR=y
+CONFIG_SECURITY_YAMA=y
+CONFIG_SECURITY_LANDLOCK=y
+CONFIG_INTEGRITY=y
+
+# ============================================================
+# Debug / Misc
+# ============================================================
+CONFIG_MAGIC_SYSRQ=y
+CONFIG_PRINTK=y
+CONFIG_PRINTK_TIME=y
+CONFIG_DMESG_RESTRICT=y
+CONFIG_PERF_EVENTS=y
+CONFIG_FTRACE=y
+CONFIG_DYNAMIC_DEBUG=y
+CONFIG_IKCONFIG=y
+CONFIG_IKCONFIG_PROC=y
+CONFIG_TTY=y
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+
+# ============================================================
+# DISABLED — hardware this machine will never have
+# ============================================================
+# CONFIG_CPU_SUP_AMD is not set
+# CONFIG_X86_AMD_PLATFORM_DEVICE is not set
+# CONFIG_AMD_IOMMU is not set
+# CONFIG_HYPERV is not set
+# CONFIG_XEN is not set
+# CONFIG_VMWARE_VMCI is not set
+# CONFIG_ISDN is not set
+# CONFIG_HAMRADIO is not set
+# CONFIG_CAN is not set
+# CONFIG_INPUT_JOYSTICK is not set
+# CONFIG_INPUT_TOUCHSCREEN is not set
+# CONFIG_INPUT_TABLET is not set
+# CONFIG_GAMEPORT is not set
+# CONFIG_PARPORT is not set
+# CONFIG_PCMCIA is not set
+# CONFIG_FB_VESA is not set
+# CONFIG_FB_VGA16 is not set

--- a/configs/MacPro5,1/fan/macfanctld.conf
+++ b/configs/MacPro5,1/fan/macfanctld.conf
@@ -1,0 +1,55 @@
+# linux-mac: Mac Pro 5,1 Fan Control Configuration
+# For use with macfanctld or custom fan control script
+#
+# Status: PLACEHOLDER — needs real hardware testing
+#
+# The Mac Pro 5,1 "cheese grater" has MULTIPLE fans unlike the 6,1:
+#   - CPU A intake fan
+#   - CPU A exhaust fan
+#   - CPU B intake fan (dual-CPU models only)
+#   - CPU B exhaust fan (dual-CPU models only)
+#   - PCI/GPU fan
+#   - Power supply fan
+#   - Optical drive fan (often removed)
+#
+# Sensors available via applesmc (paths need hardware verification):
+#   /sys/devices/platform/applesmc.768/fan*_min
+#   /sys/devices/platform/applesmc.768/fan*_max
+#   /sys/devices/platform/applesmc.768/fan*_output
+#   /sys/devices/platform/applesmc.768/temp*_input
+#
+# NOTE: The exact fan numbering and sensor mapping differs from the 6,1.
+# Someone with actual hardware needs to run:
+#   ls /sys/devices/platform/applesmc.768/fan*
+#   ls /sys/devices/platform/applesmc.768/temp*
+#   cat /sys/devices/platform/applesmc.768/temp*_label
+# and document the mapping here.
+#
+# Temperature thresholds (estimated, needs verification):
+#   CPU idle:     30-40°C
+#   CPU load:     55-75°C (Westmere runs cooler than Ivy Bridge)
+#   GPU idle:     35-45°C (stock 5770 is low power)
+#   GPU load:     60-85°C (varies wildly with GPU upgrade)
+#   Danger zone:  >95°C
+
+# --- macfanctld config (PLACEHOLDER) ---
+# These values are estimates. Do NOT deploy without hardware testing.
+
+# Minimum fan speed (RPM) — conservative
+fan_min: 800
+
+# Temperature -> fan speed curve
+temp_low: 40
+temp_high: 80
+fan_low: 800
+fan_high: 2800
+
+# Poll interval in seconds
+poll_interval: 2
+
+# --- TODO for contributors ---
+# 1. Document actual fan count and numbering on your 5,1
+# 2. Map temperature sensors to components (CPU A, CPU B, GPU, ambient)
+# 3. Determine safe min/max RPM for each fan
+# 4. Test with stock GPU and with upgraded GPU (different thermal load)
+# 5. Dual-CPU models need separate curves for CPU A and CPU B fans

--- a/configs/MacPro5,1/patches/README.md
+++ b/configs/MacPro5,1/patches/README.md
@@ -1,0 +1,20 @@
+# Mac Pro 5,1 Kernel Patches
+
+Place `.patch` files here. They will be applied during the build.
+
+## Planned Patches
+
+### efi-mixed-32bit-boot.patch (maybe)
+The Mid 2010 Mac Pro 5,1 uses 32-bit EFI firmware to boot a 64-bit OS.
+`CONFIG_EFI_MIXED=y` handles this in mainline, but there may be edge
+cases with Apple's EFI implementation that need patching.
+
+Status: Needs testing on actual 2010 hardware to determine if mainline
+EFI_MIXED support works without issues.
+
+### ichr-ahci-link-power.patch (maybe)
+The ICH10 AHCI controller may benefit from aggressive link power
+management tuning for better idle power consumption with spinning
+3.5" drives. Needs testing to confirm benefit vs reliability.
+
+Status: Not yet written — needs hardware testing.

--- a/configs/MacPro5,1/sysctl.d/99-macpro51.conf
+++ b/configs/MacPro5,1/sysctl.d/99-macpro51.conf
@@ -1,0 +1,30 @@
+# linux-mac: Mac Pro 5,1 Performance Tuning
+# Install to /etc/sysctl.d/99-macpro51.conf
+#
+# Status: Template — values based on typical 32-64GB configurations.
+# Adjust for your actual RAM size.
+
+# --- Memory (tuned for 32-64GB RAM, typical upgraded 5,1) ---
+# Keep data in RAM — 5,1 owners often have 32-64GB
+vm.swappiness = 10
+# Retain filesystem caches longer
+vm.vfs_cache_pressure = 50
+# Start flushing dirty pages at 10% of RAM
+vm.dirty_ratio = 10
+# Background writeback starts at 5% of RAM
+vm.dirty_background_ratio = 5
+
+# --- Network (tuned for dual GbE) ---
+# Larger socket buffers for throughput
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+# TCP Fast Open for client + server
+net.ipv4.tcp_fastopen = 3
+# Handle burst traffic
+net.core.netdev_max_backlog = 5000
+# Google BBR congestion control (requires CONFIG_TCP_CONG_BBR=y)
+net.ipv4.tcp_congestion_control = bbr
+
+# --- Kernel ---
+# Reduce console log noise
+kernel.printk = 3 4 1 3


### PR DESCRIPTION
## Summary

- Add template kernel configuration, hardware documentation, sysctl tuning, and fan control placeholders for the **Mac Pro 5,1** "Cheese Grater" (Mid 2010 and Mid 2012 revisions)
- Update supported models table in README and reference templates in CONTRIBUTING.md
- All hardware marked as untested — needs real hardware validation

## Hardware Highlights (vs MacPro6,1)

| Feature | MacPro5,1 | MacPro6,1 |
|---------|-----------|-----------|
| CPU | Dual Westmere Xeon (up to 12c/24t) | Single Ivy Bridge Xeon |
| GPU (stock) | Radeon HD 5770/5870 | Dual FirePro D700 |
| GPU (common upgrades) | RX 580, Vega, GTX 680/780 | N/A |
| Network | Dual GbE (tg3) | Dual GbE (tg3) |
| Expansion | FireWire 800, 4x PCIe | Thunderbolt 2 |
| EFI | 32-bit (2010) / 64-bit (2012) | 64-bit |
| NUMA | Yes (dual socket) | No |
| Fan | Multiple fans | Single centrifugal |

## Files Added

- `configs/MacPro5,1/README.md` — Hardware matrix, GPU upgrade guide, compatibility matrix
- `configs/MacPro5,1/config` — Template kernel config (both amdgpu + nouveau for GPU upgrades)
- `configs/MacPro5,1/sysctl.d/99-macpro51.conf` — Tuned for 32-64GB RAM, dual GbE
- `configs/MacPro5,1/fan/macfanctld.conf` — Placeholder (different fan layout than 6,1)
- `configs/MacPro5,1/patches/README.md` — Placeholder for model-specific patches

## Help Wanted

This config needs testing on real Mac Pro 5,1 hardware. If you have one, please:

1. Boot any Linux distro and run `lspci -nn`, `dmesg`, `cat /proc/cpuinfo`
2. Try building the kernel with this config
3. Report what works and what doesn't
4. Submit corrections via PR

## Test plan

- [ ] Verify directory structure matches MacPro6,1 pattern
- [ ] Verify README hardware specs against Apple's published specifications
- [ ] Verify kernel config compiles with `make olddefconfig` (needs a Linux build environment)
- [ ] **Needs real hardware**: Boot test on actual MacPro5,1
- [ ] **Needs real hardware**: Validate all driver/config options

🤖 Generated with [Claude Code](https://claude.com/claude-code)