### PR TITLE
Add MacPro7,1 (2019) template config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ configs/YourModel/
     └── fan.conf    # if applicable
 ```
 
+**Template configs** exist for models awaiting hardware testing — check
+`configs/MacPro5,1/` and `configs/MacPro7,1/` if you have one of those machines.
+These are ready for you to validate and refine with real hardware data.
+
 ### 5. Trim the Config
 
 Follow the pattern in `configs/MacPro6,1/config`:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A stock distro kernel ships with thousands of modules for hardware you'll never 
 | Model | Identifier | Status | Maintainer |
 |-------|-----------|--------|------------|
 | Mac Pro (Late 2013) | `MacPro6,1` | ✅ Active | @wolffcatskyy |
+| Mac Pro (2019) | `MacPro7,1` | 📋 Planned | community — [help wanted](configs/MacPro7,1/) |
 | *Your Mac here* | *submit a PR* | 🔜 | *you?* |
 
 ## Quick Start (Arch Linux)
@@ -59,14 +60,15 @@ sudo pacman -U linux-macpro61-*.pkg.tar.zst
 ```
 linux-mac/
 ├── configs/
-│   └── MacPro6,1/
-│       ├── config              # kernel .config
-│       ├── README.md           # hardware matrix, what works
-│       ├── patches/            # model-specific kernel patches
-│       ├── sysctl.d/
-│       │   └── 99-macpro.conf  # performance tuning
-│       └── fan/
-│           └── macfanctld.conf # fan curve profiles
+│   ├── MacPro6,1/              # Late 2013 "Trash Can" (active)
+│   │   ├── config              # kernel .config
+│   │   ├── README.md           # hardware matrix, what works
+│   │   ├── patches/            # model-specific kernel patches
+│   │   ├── sysctl.d/
+│   │   │   └── 99-macpro.conf  # performance tuning
+│   │   └── fan/
+│   │       └── macfanctld.conf # fan curve profiles
+│   └── MacPro7,1/              # 2019 rack (planned)
 ├── packaging/
 │   ├── arch/
 │   │   └── PKGBUILD           # AUR-ready

--- a/configs/MacPro7,1/README.md
+++ b/configs/MacPro7,1/README.md
@@ -1,0 +1,133 @@
+# Mac Pro 7,1 (2019) — "Cheese Grater Redux"
+
+> **Status: Template — needs real hardware testing**
+>
+> This configuration is based on Apple's published specs and community knowledge.
+> It has NOT been validated on actual hardware. If you have a Mac Pro 7,1,
+> please test and submit corrections via PR.
+
+## Hardware Specifications
+
+| Component | Details | Kernel Driver | Config Option |
+|-----------|---------|--------------|---------------|
+| **CPU** | Intel Xeon W-3200 series (Cascade Lake-SP): 8 to 28 cores | — | `CONFIG_NR_CPUS=56` |
+| **GPU (stock)** | Radeon Pro 580X (Polaris 20, 8GB) | `amdgpu` | `CONFIG_DRM_AMDGPU=y` |
+| **GPU (options)** | Radeon Pro Vega II (Duo), Radeon Pro W5500X/W5700X, Radeon Pro W6800X/W6900X | `amdgpu` | See GPU section below |
+| **Ethernet** | 2x 10GbE Broadcom BCM57416 (NBASE-T) | `bnxt_en` | `CONFIG_BNXT=y` |
+| **Wi-Fi** | Broadcom BCM4364 802.11ac (Wi-Fi 5) + Bluetooth 5.0 | `brcmfmac` | `CONFIG_BRCMFMAC=m` |
+| **Audio** | Intel HDA + Cirrus Logic (likely CS4208 or similar) | `snd_hda_intel` | `CONFIG_SND_HDA_INTEL=y`, `CONFIG_SND_HDA_CODEC_CIRRUS=y` |
+| **Storage** | 2x internal M.2 NVMe slots (T2-managed in macOS) | `nvme` | `CONFIG_BLK_DEV_NVME=y` |
+| **Thunderbolt** | 4x Thunderbolt 3 ports (Intel JHL7540 / Titan Ridge) | `thunderbolt` | `CONFIG_THUNDERBOLT=y` |
+| **USB** | 2x USB-A 3.0 (internal), USB-C via Thunderbolt | `xhci_hcd` | `CONFIG_USB_XHCI_HCD=y` |
+| **T2 Security Chip** | Apple T2 (controls SSD, audio, more) | See T2 section | See T2 section |
+| **Thermal** | Apple SMC | `applesmc` | `CONFIG_SENSORS_APPLESMC=y` |
+| **Boot** | EFI (64-bit, UEFI 2.x via T2) | — | `CONFIG_EFI=y`, `CONFIG_EFI_STUB=y` |
+
+## GPU Details
+
+All Mac Pro 7,1 GPUs are AMD — no Nvidia options. The range spans three AMD generations:
+
+### GPU Options (All AMD)
+
+| GPU | Architecture | VRAM | Driver | Firmware Prefix |
+|-----|-------------|------|--------|----------------|
+| Radeon Pro 580X | Polaris 20 (GCN 4) | 8GB | `amdgpu` | `amdgpu/polaris10_*` |
+| Radeon Pro Vega II | Vega 20 (GCN 5.1) | 32GB HBM2 | `amdgpu` | `amdgpu/vega20_*` |
+| Radeon Pro Vega II Duo | 2x Vega 20 (GCN 5.1) | 2x 32GB HBM2 | `amdgpu` | `amdgpu/vega20_*` |
+| Radeon Pro W5500X | Navi 14 (RDNA 1) | 8GB | `amdgpu` | `amdgpu/navi14_*` |
+| Radeon Pro W5700X | Navi 10 (RDNA 1) | 16GB | `amdgpu` | `amdgpu/navi10_*` |
+| Radeon Pro W6800X | Navi 21 (RDNA 2) | 32GB | `amdgpu` | `amdgpu/sienna_cichlid_*` |
+| Radeon Pro W6900X | Navi 21 (RDNA 2) | 32GB | `amdgpu` | `amdgpu/sienna_cichlid_*` |
+| Radeon Pro W6800X Duo | 2x Navi 21 (RDNA 2) | 2x 32GB | `amdgpu` | `amdgpu/sienna_cichlid_*` |
+
+**Note:** The kernel config should enable support for all AMD GPU generations (Polaris through RDNA 2) since different 7,1 configurations ship with different GPUs. Users can trim to their specific GPU after testing.
+
+### Afterburner Card
+
+Some 7,1 configurations include the Apple Afterburner card — an FPGA-based ProRes/ProRes RAW accelerator. There is currently no Linux driver for Afterburner. It will appear in `lspci` but won't be functional.
+
+## T2 Security Chip Considerations
+
+The Mac Pro 7,1 includes Apple's T2 chip, which mediates several hardware functions:
+
+| Function | Impact on Linux | Mitigation |
+|----------|----------------|------------|
+| **SSD Controller** | T2 encrypts NVMe storage by default | Disable FileVault in macOS before installing Linux, or use external NVMe |
+| **Audio** | T2 routes audio on some Macs | May need `apple-t2-audio-config` or `snd_hda_macbookpro` patches |
+| **Secure Boot** | T2 validates boot chain | Set Startup Security to "No Security" in Recovery Mode |
+| **Touch ID** | Fingerprint sensor | Not usable in Linux |
+
+**Recommendation:** Before installing Linux, boot into macOS Recovery and:
+1. Set Startup Security Utility to "No Security"
+2. Allow booting from external media
+3. Disable FileVault if using internal NVMe
+
+See [t2linux.org](https://t2linux.org) for community T2 Linux support.
+
+## Hardware Compatibility Matrix
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Display (DP) | 🔲 Untested | Via amdgpu + DC |
+| Display (HDMI) | 🔲 Untested | Via HDMI 2.0 on MPX Module |
+| Display (TB) | 🔲 Untested | Via Thunderbolt 3 |
+| OpenGL | 🔲 Untested | Mesa radeonsi |
+| Vulkan | 🔲 Untested | Mesa RADV |
+| GPU Compute | 🔲 Untested | ROCm support depends on GPU generation |
+| 10GbE Ethernet | 🔲 Untested | Broadcom bnxt_en driver |
+| Wi-Fi | 🔲 Untested | BCM4364 requires proprietary firmware |
+| Bluetooth | 🔲 Untested | Via T2 chip — may be problematic |
+| Audio (3.5mm) | 🔲 Untested | May require T2 audio patches |
+| Audio (HDMI/DP) | 🔲 Untested | Via amdgpu HDMI audio |
+| Thunderbolt 3 | 🔲 Untested | 4 ports via Titan Ridge |
+| USB 3.0 | 🔲 Untested | 2x USB-A + USB-C via TB |
+| Internal NVMe | 🔲 Untested | T2-managed, may need encryption disabled |
+| External NVMe | 🔲 Untested | Via PCIe or Thunderbolt — no T2 issues |
+| Sleep/Wake | ❓ Unknown | T2 complicates power management |
+| Fan Control | 🔲 Untested | Via applesmc — multiple fans |
+| Temperature Sensors | 🔲 Untested | Via applesmc + hwmon |
+| Afterburner | ❌ No driver | FPGA card — no Linux support |
+
+## Known Considerations
+
+### T2 Chip
+The T2 chip is the biggest difference from older Mac Pros. It affects boot security, storage encryption, and audio routing. See the T2 section above and [t2linux.org](https://t2linux.org) for details.
+
+### 10GbE Networking
+The 7,1 has dual 10GbE (Broadcom BCM57416 using the `bnxt_en` driver). This is a different driver family from the `tg3` used in the 5,1 and 6,1. The sysctl config includes tuning for 10GbE throughput.
+
+### MPX Module GPU Format
+The 7,1 uses Apple's proprietary MPX Module form factor for GPUs, which combines a standard PCIe GPU with a Thunderbolt bridge. The GPU itself uses standard PCIe and works with standard amdgpu drivers — the MPX connector just adds Thunderbolt passthrough for displays.
+
+### Massive RAM Support
+The 7,1 supports up to 1.5TB of DDR4 ECC RAM across 12 DIMM slots. The kernel config and sysctl are tuned for large memory configurations.
+
+## Model Variants
+
+| Model | CPU | Cores/Threads | GPU (base) | RAM Slots |
+|-------|-----|--------------|------------|-----------|
+| Base | W-3223 (8C/16T, 3.5GHz) | 8C/16T | Radeon Pro 580X (8GB) | 12 |
+| Mid | W-3245 (16C/32T, 3.2GHz) | 16C/32T | Radeon Pro 580X (8GB) | 12 |
+| High | W-3265M (24C/48T, 2.7GHz) | 24C/48T | Radeon Pro 580X (8GB) | 12 |
+| Max | W-3275M (28C/56T, 2.5GHz) | 28C/56T | Radeon Pro 580X (8GB) | 12 |
+
+All models can be configured with any of the GPU options listed above. Dual-GPU MPX modules (Vega II Duo, W6800X Duo) occupy both MPX bays.
+
+**Note:** RAM is DDR4 ECC (2933MHz). 12 DIMM slots. Apple officially supports up to 1.5TB (12x 128GB), though configurations above 768GB were BTO only.
+
+## PCI Device IDs (Base Configuration)
+
+```
+GPU:        1002:7310 or similar (AMD Polaris/Vega/Navi — varies by config)
+NIC 1:      14e4:16d7 (Broadcom BCM57416 10GbE)
+NIC 2:      14e4:16d7 (Broadcom BCM57416 10GbE)
+Wi-Fi:      14e4:4464 (Broadcom BCM4364)
+TB 1:       8086:15eb (Intel JHL7540 Titan Ridge)
+TB 2:       8086:15eb (Intel JHL7540 Titan Ridge)
+USB:        8086:* (Intel xHCI)
+HDA:        8086:* (Intel HDA controller)
+T2:         106b:* (Apple T2 coprocessor)
+NVMe:       106b:* (Apple/T2 NVMe controller)
+```
+
+**Note:** PCI IDs vary significantly based on GPU configuration. Use `lspci -nn` on your system to verify.

--- a/configs/MacPro7,1/config
+++ b/configs/MacPro7,1/config
@@ -1,0 +1,520 @@
+#
+# linux-mac: Kernel configuration for Mac Pro 7,1 (2019)
+#
+# !! TEMPLATE — NOT TESTED ON REAL HARDWARE !!
+# This config is based on Apple specs and community knowledge.
+# It needs validation on an actual Mac Pro 7,1.
+# If you have one, please test and submit fixes via PR.
+#
+# Target: Linux 6.19
+# CPU: Intel Xeon W-3200 series (Cascade Lake-SP), 8 to 28 cores
+# GPU: Radeon Pro 580X (stock) — see GPU section for other options
+# RAM: Up to 1.5TB DDR4 ECC (12 DIMM slots)
+# Storage: 2x internal NVMe (T2-managed), PCIe slots available
+# Network: 2x 10GbE Broadcom BCM57416 + BCM4364 Wi-Fi
+# Audio: Intel HDA + Cirrus Logic (via T2 on some paths)
+# Thunderbolt: 4x Thunderbolt 3 (Intel Titan Ridge JHL7540)
+# Boot: EFI stub, no initramfs
+#
+# Philosophy: Everything needed is built-in (=y) where possible.
+# Modules (=m) for things that are optional or vary between machines.
+# Disabled (not set) for hardware this machine will never have.
+#
+# T2 NOTE: The 7,1 has an Apple T2 chip that manages SSD encryption,
+# audio routing, and secure boot. Set Startup Security to "No Security"
+# before installing Linux. See README.md for details.
+#
+
+# ============================================================
+# Architecture — must be explicitly set
+# ============================================================
+CONFIG_64BIT=y
+CONFIG_X86_64=y
+CONFIG_X86=y
+CONFIG_SMP=y
+CONFIG_NR_CPUS=56
+
+# ============================================================
+# General setup
+# ============================================================
+CONFIG_LOCALVERSION=""
+CONFIG_LOCALVERSION_AUTO=n
+CONFIG_DEFAULT_HOSTNAME="macpro"
+CONFIG_KERNEL_ZSTD=y
+CONFIG_SYSVIPC=y
+CONFIG_POSIX_MQUEUE=y
+CONFIG_AUDIT=y
+CONFIG_AUDITSYSCALL=y
+CONFIG_NO_HZ_FULL=y
+CONFIG_HIGH_RES_TIMERS=y
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+CONFIG_BPF_JIT_ALWAYS_ON=y
+CONFIG_BPF_LSM=y
+CONFIG_PREEMPT=y
+CONFIG_HZ_1000=y
+CONFIG_SCHED_AUTOGROUP=y
+CONFIG_SCHED_CORE=y
+CONFIG_TASKSTATS=y
+CONFIG_TASK_DELAY_ACCT=y
+CONFIG_TASK_XACCT=y
+CONFIG_TASK_IO_ACCOUNTING=y
+CONFIG_PSI=y
+CONFIG_FHANDLE=y
+CONFIG_EPOLL=y
+CONFIG_SIGNALFD=y
+CONFIG_TIMERFD=y
+CONFIG_EVENTFD=y
+CONFIG_SHMEM=y
+CONFIG_AIO=y
+CONFIG_ADVISE_SYSCALLS=y
+CONFIG_IO_URING=y
+CONFIG_KCMP=y
+CONFIG_CHECKPOINT_RESTORE=y
+CONFIG_CROSS_MEMORY_ATTACH=y
+
+# ============================================================
+# Modules — required for DKMS (broadcom-wl, etc.)
+# ============================================================
+CONFIG_MODULES=y
+CONFIG_MODULE_UNLOAD=y
+CONFIG_MODULE_FORCE_UNLOAD=y
+
+# ============================================================
+# Cgroups / Namespaces (Docker, systemd, containers)
+# ============================================================
+CONFIG_CGROUPS=y
+CONFIG_CGROUP_SCHED=y
+CONFIG_CGROUP_CPUACCT=y
+CONFIG_CGROUP_FREEZER=y
+CONFIG_CGROUP_DEVICE=y
+CONFIG_CGROUP_BPF=y
+CONFIG_CGROUP_PIDS=y
+CONFIG_CGROUP_HUGETLB=y
+CONFIG_CGROUP_PERF=y
+CONFIG_CGROUP_NET_PRIO=y
+CONFIG_MEMCG=y
+CONFIG_BLK_CGROUP=y
+CONFIG_PAGE_COUNTER=y
+CONFIG_NAMESPACES=y
+CONFIG_USER_NS=y
+CONFIG_NET_NS=y
+CONFIG_PID_NS=y
+CONFIG_IPC_NS=y
+CONFIG_UTS_NS=y
+
+# ============================================================
+# PCI / Block layer — fundamentals
+# ============================================================
+CONFIG_PCI=y
+CONFIG_PCIEPORTBUS=y
+CONFIG_HOTPLUG_PCI_PCIE=y
+CONFIG_BLOCK=y
+CONFIG_BLK_WBT=y
+CONFIG_MQ_DEADLINE=y
+CONFIG_BFQ_GROUP_IOSCHED=y
+
+# ============================================================
+# Processor (Cascade Lake-SP / Skylake-SP)
+# ============================================================
+# Cascade Lake is a refinement of Skylake-SP. Generic CPU works fine.
+# For mainline, -march=native via MARCH_NATIVE (6.x+) is ideal.
+CONFIG_X86_MCE=y
+CONFIG_X86_MCE_INTEL=y
+CONFIG_MICROCODE=y
+CONFIG_MICROCODE_INTEL=y
+# CONFIG_MICROCODE_AMD is not set
+CONFIG_X86_MSR=y
+CONFIG_X86_CPUID=y
+# Single socket but Cascade Lake-SP supports sub-NUMA clustering
+CONFIG_NUMA=y
+CONFIG_CPU_FREQ=y
+CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE=y
+CONFIG_CPU_FREQ_GOV_PERFORMANCE=y
+CONFIG_CPU_FREQ_GOV_POWERSAVE=y
+CONFIG_CPU_FREQ_GOV_ONDEMAND=y
+CONFIG_X86_ACPI_CPUFREQ=y
+CONFIG_X86_INTEL_PSTATE=y
+# CONFIG_X86_AMD_FREQ_SENSITIVITY is not set
+CONFIG_INTEL_IDLE=y
+# Cascade Lake has Intel Speed Select Technology
+CONFIG_INTEL_SPEED_SELECT_INTERFACE=y
+
+# ============================================================
+# Memory management (up to 1.5TB)
+# ============================================================
+CONFIG_TRANSPARENT_HUGEPAGE=y
+CONFIG_TRANSPARENT_HUGEPAGE_MADVISE=y
+CONFIG_ZSWAP=y
+CONFIG_ZSMALLOC=y
+CONFIG_SLAB_FREELIST_RANDOM=y
+CONFIG_SHUFFLE_PAGE_ALLOCATOR=y
+
+# ============================================================
+# Power management
+# ============================================================
+CONFIG_PM=y
+CONFIG_ACPI=y
+CONFIG_ACPI_PROCESSOR=y
+CONFIG_ACPI_THERMAL=y
+CONFIG_ACPI_FAN=y
+# CONFIG_ACPI_AC is not set
+# CONFIG_ACPI_BATTERY is not set
+# CONFIG_ACPI_SBS is not set
+
+# ============================================================
+# EFI / Boot (Apple EFI via T2, no initramfs)
+# ============================================================
+CONFIG_EFI=y
+CONFIG_EFI_STUB=y
+CONFIG_EFI_MIXED=y
+CONFIG_EFIVAR_FS=y
+CONFIG_FB_EFI=y
+CONFIG_FRAMEBUFFER_CONSOLE=y
+CONFIG_EFI_PARTITION=y
+# CONFIG_BLK_DEV_INITRD is not set
+
+# ============================================================
+# Firmware loading — support zstd-compressed firmware blobs
+# ============================================================
+CONFIG_FW_LOADER=y
+CONFIG_FW_LOADER_COMPRESS=y
+CONFIG_FW_LOADER_COMPRESS_ZSTD=y
+
+# GPU firmware blobs built into kernel (for boot without initramfs)
+# Stock 580X (Polaris 10) firmware — change to match YOUR GPU
+# See README.md for firmware names for other GPUs
+CONFIG_EXTRA_FIRMWARE="amdgpu/polaris10_ce.bin amdgpu/polaris10_ce_2.bin amdgpu/polaris10_k_smc.bin amdgpu/polaris10_mc.bin amdgpu/polaris10_me.bin amdgpu/polaris10_me_2.bin amdgpu/polaris10_mec.bin amdgpu/polaris10_mec2.bin amdgpu/polaris10_mec2_2.bin amdgpu/polaris10_mec_2.bin amdgpu/polaris10_pfp.bin amdgpu/polaris10_pfp_2.bin amdgpu/polaris10_rlc.bin amdgpu/polaris10_sdma.bin amdgpu/polaris10_sdma1.bin amdgpu/polaris10_smc.bin amdgpu/polaris10_smc_sk.bin amdgpu/polaris10_uvd.bin amdgpu/polaris10_vce.bin"
+CONFIG_EXTRA_FIRMWARE_DIR="/lib/firmware"
+
+# ============================================================
+# GPU — AMD Radeon Pro (Polaris / Vega / RDNA 1 / RDNA 2)
+# ============================================================
+# All 7,1 GPUs are AMD. Enable broad support since configs vary.
+# Users should trim firmware blobs to their specific GPU.
+CONFIG_DRM=y
+CONFIG_DRM_AMDGPU=y
+CONFIG_DRM_AMDGPU_SI=y
+CONFIG_DRM_AMDGPU_CIK=y
+CONFIG_DRM_AMDGPU_USERPTR=y
+CONFIG_HSA_AMD=y
+CONFIG_DRM_AMD_DC=y
+CONFIG_DRM_AMD_DC_SI=y
+
+# No Nvidia GPUs available for the 7,1 (MPX Module format, AMD only)
+# CONFIG_DRM_NOUVEAU is not set
+# CONFIG_DRM_RADEON is not set
+# CONFIG_DRM_I915 is not set
+# CONFIG_DRM_VGEM is not set
+# CONFIG_DRM_VMWGFX is not set
+# CONFIG_DRM_BOCHS is not set
+# CONFIG_DRM_AST is not set
+# CONFIG_DRM_MGAG200 is not set
+
+# ============================================================
+# KVM — for macOS virtualization
+# ============================================================
+CONFIG_VIRTUALIZATION=y
+CONFIG_KVM=y
+CONFIG_KVM_INTEL=y
+# CONFIG_KVM_AMD is not set
+CONFIG_VHOST=y
+CONFIG_VHOST_NET=y
+CONFIG_VHOST_VSOCK=y
+
+# Virtio for guests
+CONFIG_VIRTIO=y
+CONFIG_VIRTIO_PCI=y
+CONFIG_VIRTIO_NET=y
+CONFIG_VIRTIO_BLK=y
+CONFIG_VIRTIO_BALLOON=y
+CONFIG_DRM_VIRTIO_GPU=m
+CONFIG_DRM_QXL=m
+
+# ============================================================
+# Storage — NVMe (internal via T2 + PCIe) + AHCI for SATA
+# ============================================================
+CONFIG_SCSI=y
+CONFIG_BLK_DEV_SD=y
+CONFIG_BLK_DEV_SR=y
+CONFIG_CHR_DEV_SG=y
+CONFIG_ATA=y
+CONFIG_SATA_AHCI=y
+CONFIG_ATA_SFF=y
+CONFIG_ATA_BMDMA=y
+# Primary storage is NVMe
+CONFIG_BLK_DEV_NVME=y
+
+# Device mapper (for LUKS, LVM, etc.)
+CONFIG_BLK_DEV_DM=m
+CONFIG_DM_CRYPT=m
+CONFIG_DM_SNAPSHOT=m
+CONFIG_DM_MIRROR=m
+CONFIG_DM_ZERO=m
+
+# ============================================================
+# Filesystem
+# ============================================================
+CONFIG_EXT4_FS=y
+CONFIG_EXT4_FS_POSIX_ACL=y
+CONFIG_EXT4_FS_SECURITY=y
+CONFIG_XFS_FS=y
+CONFIG_BTRFS_FS=y
+CONFIG_TMPFS=y
+CONFIG_TMPFS_POSIX_ACL=y
+CONFIG_VFAT_FS=y
+CONFIG_FAT_DEFAULT_CODEPAGE=437
+CONFIG_NLS_CODEPAGE_437=y
+CONFIG_NLS_ISO8859_1=y
+CONFIG_NLS_ASCII=y
+CONFIG_NLS_UTF8=y
+CONFIG_NLS_DEFAULT="utf8"
+CONFIG_FAT_DEFAULT_UTF8=y
+CONFIG_FUSE_FS=y
+CONFIG_OVERLAY_FS=y
+CONFIG_PROC_FS=y
+CONFIG_SYSFS=y
+CONFIG_DEVTMPFS=y
+CONFIG_DEVTMPFS_MOUNT=y
+CONFIG_HFSPLUS_FS=m
+CONFIG_HFS_FS=m
+CONFIG_AUTOFS_FS=y
+# CONFIG_OCFS2_FS is not set
+# CONFIG_GFS2_FS is not set
+# CONFIG_NILFS2_FS is not set
+# CONFIG_F2FS_FS is not set
+# CONFIG_JFS_FS is not set
+# CONFIG_REISERFS_FS is not set
+
+# NFS client (for NAS mounts)
+CONFIG_NFS_FS=m
+CONFIG_NFS_V3=m
+CONFIG_NFS_V4=m
+CONFIG_LOCKD=m
+CONFIG_SUNRPC=m
+
+# ============================================================
+# Network — Broadcom BCM57416 10GbE + BCM4364 Wi-Fi
+# ============================================================
+CONFIG_NET=y
+CONFIG_PACKET=y
+CONFIG_UNIX=y
+CONFIG_INET=y
+CONFIG_IPV6=y
+CONFIG_NETFILTER=y
+CONFIG_NF_CONNTRACK=y
+CONFIG_NETFILTER_XTABLES=y
+CONFIG_NF_NAT=y
+CONFIG_NF_TABLES=m
+CONFIG_IP_NF_IPTABLES=y
+CONFIG_IP_NF_FILTER=y
+CONFIG_IP_NF_NAT=y
+CONFIG_IP_NF_MANGLE=y
+CONFIG_IP_NF_TARGET_MASQUERADE=m
+CONFIG_IP6_NF_IPTABLES=m
+CONFIG_IP6_NF_FILTER=m
+CONFIG_IP6_NF_NAT=m
+CONFIG_BRIDGE=m
+CONFIG_BRIDGE_NETFILTER=m
+CONFIG_VLAN_8021Q=m
+CONFIG_NET_SCHED=y
+CONFIG_NET_SCH_FQ_CODEL=y
+CONFIG_NET_CLS_CGROUP=y
+
+# Wired — Broadcom BCM57416 10GbE (NOT tg3 — different driver family)
+CONFIG_NET_VENDOR_BROADCOM=y
+CONFIG_BNXT=y
+CONFIG_BNXT_SRIOV=y
+# tg3 not needed on 7,1 but kept as module for compatibility
+CONFIG_TIGON3=m
+
+# Wireless — BCM4364 (Wi-Fi 5)
+CONFIG_WLAN=y
+CONFIG_CFG80211=m
+CONFIG_MAC80211=m
+CONFIG_WLAN_VENDOR_BROADCOM=y
+CONFIG_BRCMFMAC=m
+CONFIG_BRCMUTIL=m
+
+# TCP — tuned for 10GbE
+CONFIG_TCP_CONG_ADVANCED=y
+CONFIG_TCP_CONG_BBR=y
+CONFIG_DEFAULT_BBR=y
+
+# Docker networking
+CONFIG_VETH=m
+CONFIG_MACVLAN=m
+CONFIG_IPVLAN=m
+CONFIG_VXLAN=m
+CONFIG_DUMMY=m
+CONFIG_TUN=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_IPVS=m
+CONFIG_IP_VS=m
+CONFIG_IP_VS_NFCT=y
+CONFIG_IP_VS_RR=m
+CONFIG_IP_VS_WRR=m
+CONFIG_IP_VS_SH=m
+CONFIG_IP_SET=m
+
+# Disable unused NIC vendors
+# CONFIG_NET_VENDOR_INTEL is not set
+# CONFIG_NET_VENDOR_REALTEK is not set
+# CONFIG_NET_VENDOR_QUALCOMM is not set
+# CONFIG_NET_VENDOR_MELLANOX is not set
+# CONFIG_NET_VENDOR_CHELSIO is not set
+# CONFIG_NET_VENDOR_MARVELL is not set
+# CONFIG_NET_VENDOR_AMD is not set
+# CONFIG_INFINIBAND is not set
+
+# ============================================================
+# Audio — Intel HDA + Cirrus Logic (T2 may mediate)
+# ============================================================
+# NOTE: Audio on the 7,1 may require t2linux patches.
+# The T2 chip routes some audio paths.
+CONFIG_SOUND=y
+CONFIG_SND=y
+CONFIG_SND_PCI=y
+CONFIG_SND_HDA_INTEL=y
+CONFIG_SND_HDA_CODEC_CIRRUS=y
+CONFIG_SND_HDA_CODEC_CS420X=y
+CONFIG_SND_HDA_CODEC_HDMI=y
+CONFIG_SND_HDA_GENERIC=y
+CONFIG_SND_USB=y
+CONFIG_SND_USB_AUDIO=m
+
+# ============================================================
+# USB — xHCI (USB 3.0) + Thunderbolt USB-C
+# ============================================================
+CONFIG_USB=y
+CONFIG_USB_XHCI_HCD=y
+CONFIG_USB_EHCI_HCD=y
+CONFIG_USB_OHCI_HCD=y
+CONFIG_USB_OHCI_HCD_PCI=y
+CONFIG_USB_STORAGE=y
+CONFIG_USB_UAS=y
+CONFIG_USB_HID=y
+CONFIG_HID=y
+CONFIG_HID_GENERIC=y
+CONFIG_HID_APPLE=y
+CONFIG_HID_MULTITOUCH=m
+CONFIG_INPUT_EVDEV=y
+
+# ============================================================
+# Video — UVC (for USB/Thunderbolt webcams)
+# ============================================================
+CONFIG_MEDIA_SUPPORT=y
+CONFIG_MEDIA_USB_SUPPORT=y
+CONFIG_USB_VIDEO_CLASS=m
+CONFIG_VIDEO_DEV=y
+
+# ============================================================
+# Thunderbolt 3 (Intel Titan Ridge JHL7540)
+# ============================================================
+CONFIG_THUNDERBOLT=y
+
+# ============================================================
+# FireWire — not present on 7,1 (no FireWire ports)
+# ============================================================
+# CONFIG_FIREWIRE is not set
+
+# ============================================================
+# Intel chipset / platform drivers (C621 / Lewisburg PCH)
+# ============================================================
+CONFIG_DMADEVICES=y
+CONFIG_INTEL_IOATDMA=y
+CONFIG_DCA=y
+CONFIG_I2C=y
+CONFIG_I2C_I801=y
+CONFIG_I2C_SMBUS=y
+CONFIG_LPC_ICH=y
+CONFIG_INTEL_MEI=y
+CONFIG_INTEL_MEI_ME=y
+CONFIG_VIDEO=y
+CONFIG_WMI=y
+# Intel IOMMU for PCIe passthrough (useful for GPU passthrough to VMs)
+CONFIG_INTEL_IOMMU=y
+CONFIG_INTEL_IOMMU_DEFAULT_ON=y
+
+# ============================================================
+# Apple hardware
+# ============================================================
+CONFIG_HWMON=y
+CONFIG_THERMAL=y
+CONFIG_SENSORS_APPLESMC=y
+CONFIG_SENSORS_CORETEMP=y
+CONFIG_X86_PKG_TEMP_THERMAL=y
+CONFIG_APPLE_GMUX=y
+
+# Intel power management / performance monitoring
+CONFIG_INTEL_POWERCLAMP=m
+CONFIG_INTEL_RAPL=m
+CONFIG_INTEL_UNCORE=m
+CONFIG_INTEL_CSTATE=m
+CONFIG_EDAC=y
+
+# ============================================================
+# Crypto — hardware accelerated (AES-NI, AVX-512 on Cascade Lake)
+# ============================================================
+CONFIG_CRYPTO=y
+CONFIG_CRYPTO_AES=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+CONFIG_CRYPTO_HASH=y
+CONFIG_CRYPTO_HMAC=y
+CONFIG_CRYPTO_SHA256=y
+CONFIG_CRYPTO_SHA512=y
+CONFIG_CRYPTO_GHASH_CLMUL_NI_INTEL=y
+CONFIG_CRYPTO_USER_API=m
+CONFIG_CRYPTO_USER_API_HASH=m
+CONFIG_CRYPTO_USER_API_SKCIPHER=m
+CONFIG_KEY_DH_OPERATIONS=y
+
+# ============================================================
+# Security
+# ============================================================
+CONFIG_SECURITY=y
+CONFIG_SECURITYFS=y
+CONFIG_SECURITY_NETWORK=y
+CONFIG_LSM="landlock,lockdown,yama,integrity,apparmor,bpf"
+CONFIG_SECURITY_APPARMOR=y
+CONFIG_SECURITY_YAMA=y
+CONFIG_SECURITY_LANDLOCK=y
+CONFIG_INTEGRITY=y
+
+# ============================================================
+# Debug / Misc
+# ============================================================
+CONFIG_MAGIC_SYSRQ=y
+CONFIG_PRINTK=y
+CONFIG_PRINTK_TIME=y
+CONFIG_DMESG_RESTRICT=y
+CONFIG_PERF_EVENTS=y
+CONFIG_FTRACE=y
+CONFIG_DYNAMIC_DEBUG=y
+CONFIG_IKCONFIG=y
+CONFIG_IKCONFIG_PROC=y
+CONFIG_TTY=y
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+
+# ============================================================
+# DISABLED — hardware this machine will never have
+# ============================================================
+# CONFIG_CPU_SUP_AMD is not set
+# CONFIG_X86_AMD_PLATFORM_DEVICE is not set
+# CONFIG_AMD_IOMMU is not set
+# CONFIG_HYPERV is not set
+# CONFIG_XEN is not set
+# CONFIG_VMWARE_VMCI is not set
+# CONFIG_ISDN is not set
+# CONFIG_HAMRADIO is not set
+# CONFIG_CAN is not set
+# CONFIG_INPUT_JOYSTICK is not set
+# CONFIG_INPUT_TOUCHSCREEN is not set
+# CONFIG_INPUT_TABLET is not set
+# CONFIG_GAMEPORT is not set
+# CONFIG_PARPORT is not set
+# CONFIG_PCMCIA is not set
+# CONFIG_FB_VESA is not set
+# CONFIG_FB_VGA16 is not set

--- a/configs/MacPro7,1/fan/macfanctld.conf
+++ b/configs/MacPro7,1/fan/macfanctld.conf
@@ -1,0 +1,49 @@
+# linux-mac: Mac Pro 7,1 Fan Control Configuration
+# For use with macfanctld or custom fan control script
+#
+# Status: PLACEHOLDER — needs real hardware testing
+#
+# The Mac Pro 7,1 has a sophisticated cooling system with multiple fans:
+#   - 3x large impeller fans (top exhaust)
+#   - Various internal fans for specific zones
+#   - The exact count and layout needs hardware verification
+#
+# Sensors available via applesmc (paths need hardware verification):
+#   /sys/devices/platform/applesmc.768/fan*_min
+#   /sys/devices/platform/applesmc.768/fan*_max
+#   /sys/devices/platform/applesmc.768/fan*_output
+#   /sys/devices/platform/applesmc.768/temp*_input
+#
+# NOTE: The T2 chip may mediate fan control on the 7,1. If applesmc
+# doesn't expose fans, the T2 may be managing them independently.
+# This is one of the things that needs hardware testing to determine.
+#
+# Temperature thresholds (estimated, needs verification):
+#   CPU idle:     30-40°C (Cascade Lake has good idle temps)
+#   CPU load:     60-85°C (28-core configs run hotter)
+#   GPU idle:     35-45°C
+#   GPU load:     70-95°C (Vega II / W6800X can run very hot)
+#   Danger zone:  >100°C
+
+# --- macfanctld config (PLACEHOLDER) ---
+# These values are estimates. Do NOT deploy without hardware testing.
+
+# Minimum fan speed (RPM) — conservative
+fan_min: 800
+
+# Temperature -> fan speed curve
+temp_low: 40
+temp_high: 85
+fan_low: 800
+fan_high: 2400
+
+# Poll interval in seconds
+poll_interval: 2
+
+# --- TODO for contributors ---
+# 1. Determine if applesmc or T2 controls fans on the 7,1
+# 2. Document actual fan count, numbering, and zone mapping
+# 3. Map temperature sensors to components (CPU, GPU, ambient, VRM)
+# 4. Determine safe min/max RPM for each fan
+# 5. Test with different GPU configurations (580X vs Vega II vs W6800X)
+# 6. Document whether the T2 chip overrides manual fan control

--- a/configs/MacPro7,1/patches/README.md
+++ b/configs/MacPro7,1/patches/README.md
@@ -1,0 +1,27 @@
+# Mac Pro 7,1 Kernel Patches
+
+Place `.patch` files here. They will be applied during the build.
+
+## Planned Patches
+
+### t2-audio.patch (likely needed)
+The T2 chip mediates audio on the 7,1. Mainline Linux may not
+correctly route audio through the T2. The t2linux.org community
+maintains patches for T2 audio support.
+
+Status: Investigate patches from https://github.com/t2linux/linux-t2-patches
+and adapt for this kernel config.
+
+### t2-bluetooth.patch (likely needed)
+Bluetooth is routed through the T2 chip and requires special
+firmware loading. The t2linux community has working patches.
+
+Status: Investigate t2linux patches for Bluetooth support.
+
+### thunderbolt-titan-ridge.patch (maybe)
+The 7,1 uses Intel Titan Ridge (JHL7540) Thunderbolt 3 controllers.
+Mainline support should work, but there may be quirks with Apple's
+implementation (especially for hot-plugging Thunderbolt displays
+through MPX modules).
+
+Status: Needs testing on hardware to identify any issues.

--- a/configs/MacPro7,1/sysctl.d/99-macpro71.conf
+++ b/configs/MacPro7,1/sysctl.d/99-macpro71.conf
@@ -1,0 +1,39 @@
+# linux-mac: Mac Pro 7,1 Performance Tuning
+# Install to /etc/sysctl.d/99-macpro71.conf
+#
+# Status: Template — values tuned for large-memory, 10GbE configurations.
+# Adjust for your actual RAM size and network setup.
+
+# --- Memory (tuned for 192-768GB+ RAM) ---
+# With this much RAM, swapping should almost never happen
+vm.swappiness = 5
+# Aggressively retain filesystem caches
+vm.vfs_cache_pressure = 30
+# Large RAM means we can handle more dirty pages before flushing
+vm.dirty_ratio = 15
+vm.dirty_background_ratio = 5
+# Allow larger mmap regions (useful for large GPU workloads)
+vm.max_map_count = 1048576
+
+# --- Network (tuned for dual 10GbE) ---
+# Much larger socket buffers for 10GbE throughput
+net.core.rmem_max = 67108864
+net.core.wmem_max = 67108864
+net.core.rmem_default = 1048576
+net.core.wmem_default = 1048576
+# TCP buffer auto-tuning for 10GbE
+net.ipv4.tcp_rmem = 4096 1048576 67108864
+net.ipv4.tcp_wmem = 4096 1048576 67108864
+# TCP Fast Open for client + server
+net.ipv4.tcp_fastopen = 3
+# Handle burst traffic on 10GbE
+net.core.netdev_max_backlog = 50000
+net.core.netdev_budget = 600
+# Google BBR congestion control (requires CONFIG_TCP_CONG_BBR=y)
+net.ipv4.tcp_congestion_control = bbr
+# Increase connection tracking for server workloads
+net.netfilter.nf_conntrack_max = 262144
+
+# --- Kernel ---
+# Reduce console log noise
+kernel.printk = 3 4 1 3


### PR DESCRIPTION
## Summary

- Add template kernel configuration, hardware documentation, sysctl tuning, and fan control placeholders for the **Mac Pro 7,1** (2019)
- Update supported models table in README and reference templates in CONTRIBUTING.md
- All hardware marked as untested — needs real hardware validation
- Includes T2 security chip documentation and considerations

## Hardware Highlights (vs MacPro6,1)

| Feature | MacPro7,1 | MacPro6,1 |
|---------|-----------|-----------|
| CPU | Xeon W-3200 Cascade Lake (up to 28c/56t) | Single Ivy Bridge Xeon |
| GPU | All-AMD: Polaris, Vega, RDNA 1/2 (MPX Module) | Dual FirePro D700 |
| Network | **Dual 10GbE** (bnxt_en) + Wi-Fi 5 | Dual GbE (tg3) |
| Expansion | 4x Thunderbolt 3 | Thunderbolt 2 |
| RAM | Up to 1.5TB DDR4 (12 DIMMs) | Up to 64GB DDR3 |
| Security | **Apple T2 chip** | None |
| IOMMU | Intel VT-d | Intel VT-d |

## T2 Chip Considerations

The biggest differentiator. Affects:
- **SSD encryption** — T2 encrypts by default, disable FileVault before Linux install
- **Audio routing** — may need t2linux patches
- **Secure Boot** — set to "No Security" in Recovery
- **Bluetooth** — routed through T2

Documentation references [t2linux.org](https://t2linux.org) community resources.

## Files Added

- `configs/MacPro7,1/README.md` — Hardware matrix, T2 docs, GPU options table, MPX Module notes
- `configs/MacPro7,1/config` — Template kernel config (10GbE bnxt_en, IOMMU, broad AMD GPU support)
- `configs/MacPro7,1/sysctl.d/99-macpro71.conf` — Tuned for large RAM (192GB+) and 10GbE
- `configs/MacPro7,1/fan/macfanctld.conf` — Placeholder (T2 may mediate fan control)
- `configs/MacPro7,1/patches/README.md` — Placeholder (T2 audio/bluetooth patches likely needed)

## Help Wanted

This config needs testing on real Mac Pro 7,1 hardware. If you have one, please:

1. Boot any Linux distro and run `lspci -nn`, `dmesg`, `cat /proc/cpuinfo`
2. Document T2 behavior (fan control, audio, SSD access)
3. Try building the kernel with this config
4. Report what works and what doesn't
5. Submit corrections via PR

## Test plan

- [ ] Verify directory structure matches MacPro6,1 pattern
- [ ] Verify README hardware specs against Apple's published specifications
- [ ] Verify kernel config compiles with `make olddefconfig` (needs a Linux build environment)
- [ ] **Needs real hardware**: Boot test on actual MacPro7,1
- [ ] **Needs real hardware**: Validate T2 chip interaction (fans, audio, SSD)
- [ ] **Needs real hardware**: Test 10GbE bnxt_en driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)